### PR TITLE
Add a destination configuration with a unit test

### DIFF
--- a/config/destination.go
+++ b/config/destination.go
@@ -1,0 +1,48 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"github.com/conduitio/conduit-connector-oracle/config/validator"
+	"github.com/conduitio/conduit-connector-oracle/models"
+)
+
+// A Destination represents a destination configuration needed for the destination connector.
+type Destination struct {
+	General
+	// KeyColumn is a column name that records should use for their Key fields (source)
+	// or used to detect if the target table already contains the record (destination).
+	KeyColumn string `validate:"lte=128,omitempty,oracle"`
+}
+
+// ParseDestination parses destination configuration into a configuration Destination struct.
+func ParseDestination(cfg map[string]string) (Destination, error) {
+	config, err := parseGeneral(cfg)
+	if err != nil {
+		return Destination{}, err
+	}
+
+	destinationConfig := Destination{
+		General:   config,
+		KeyColumn: cfg[models.ConfigKeyColumn],
+	}
+
+	err = validator.Validate(destinationConfig)
+	if err != nil {
+		return Destination{}, err
+	}
+
+	return destinationConfig, nil
+}

--- a/config/destination_test.go
+++ b/config/destination_test.go
@@ -1,0 +1,113 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/conduitio/conduit-connector-oracle/config/validator"
+	"github.com/conduitio/conduit-connector-oracle/models"
+)
+
+func TestParseDestination(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          map[string]string
+		want        Destination
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name: "valid config",
+			in: map[string]string{
+				models.ConfigURL:   "test_user/test_pass_123@localhost:1521/db_name",
+				models.ConfigTable: "test_table",
+			},
+			want: Destination{
+				General: General{
+					URL:   "test_user/test_pass_123@localhost:1521/db_name",
+					Table: "test_table",
+				},
+			},
+		},
+		{
+			name: "valid config with a key column",
+			in: map[string]string{
+				models.ConfigURL:       "test_user/test_pass_123@localhost:1521/db_name",
+				models.ConfigTable:     "test_table",
+				models.ConfigKeyColumn: "test_column",
+			},
+			want: Destination{
+				General: General{
+					URL:   "test_user/test_pass_123@localhost:1521/db_name",
+					Table: "test_table",
+				},
+				KeyColumn: "test_column",
+			},
+		},
+		{
+			name: "key column is one symbol length",
+			in: map[string]string{
+				models.ConfigURL:       "test_user/test_pass_123@localhost:1521/db_name",
+				models.ConfigTable:     "test_table",
+				models.ConfigKeyColumn: "t",
+			},
+			want: Destination{
+				General: General{
+					URL:   "test_user/test_pass_123@localhost:1521/db_name",
+					Table: "test_table",
+				},
+				KeyColumn: "t",
+			},
+		},
+		{
+			name: "key column is too long",
+			in: map[string]string{
+				models.ConfigURL:   "test_user/test_pass_123@localhost:1521/db_name",
+				models.ConfigTable: "test_table",
+				models.ConfigKeyColumn: "test_column_test_column_test_column_test_column_test_column_" +
+					"test_column_test_column_test_column_test_column_test_column_test_colu",
+			},
+			wantErr:     true,
+			expectedErr: validator.OutOfRangeErr(models.ConfigKeyColumn).Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseDestination(tt.in)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("parse error = \"%s\", wantErr %t", err.Error(), tt.wantErr)
+
+					return
+				}
+
+				if err.Error() != tt.expectedErr {
+					t.Errorf("expected error \"%s\", got \"%s\"", tt.expectedErr, err.Error())
+
+					return
+				}
+
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parse = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/config/general.go
+++ b/config/general.go
@@ -23,8 +23,7 @@ import (
 type General struct {
 	// URL is the configuration of the connection string to connect to Oracle database.
 	URL string `json:"url" validate:"required"`
-
-	// Table is the configuration of the table.
+	// Table is the configuration of the table name.
 	Table string `json:"table" validate:"required,lte=128,oracle"`
 }
 

--- a/models/config.go
+++ b/models/config.go
@@ -15,17 +15,19 @@
 package models
 
 const (
-	// ConfigURL is the configuration name of the connection string to connect to Oracle database.
+	// ConfigURL is the configuration name of the url.
 	ConfigURL = "url"
-
 	// ConfigTable is the configuration name of the table.
 	ConfigTable = "table"
+	// ConfigKeyColumn is the configuration name of the key column.
+	ConfigKeyColumn = "keyColumn"
 )
 
 // ConfigKeyName returns a configuration key name by struct field.
 func ConfigKeyName(fieldName string) string {
 	return map[string]string{
-		"URL":   ConfigURL,
-		"Table": ConfigTable,
+		"URL":       ConfigURL,
+		"Table":     ConfigTable,
+		"KeyColumn": ConfigKeyColumn,
 	}[fieldName]
 }

--- a/spec.go
+++ b/spec.go
@@ -15,6 +15,7 @@
 package oracle
 
 import (
+	"github.com/conduitio/conduit-connector-oracle/models"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 
@@ -25,9 +26,24 @@ func Specification() sdk.Specification {
 		Summary: "Oracle source and destination plugin for Conduit, written in Go.",
 		Description: "Oracle connector is one of Conduit plugins. " +
 			"It provides a source and a destination Oracle connector.",
-		Version:           "v0.1.0",
-		Author:            "Meroxa, Inc.",
-		SourceParams:      map[string]sdk.Parameter{},
-		DestinationParams: map[string]sdk.Parameter{},
+		Version:      "v0.1.0",
+		Author:       "Meroxa, Inc.",
+		SourceParams: map[string]sdk.Parameter{},
+		DestinationParams: map[string]sdk.Parameter{
+			models.ConfigURL: {
+				Default:     "",
+				Required:    true,
+				Description: "The connection string to connect to Oracle database.",
+			},
+			models.ConfigTable: {
+				Default:     "",
+				Required:    true,
+				Description: "The table name of the table in Oracle that the connector should write to, by default.",
+			},
+			models.ConfigKeyColumn: {
+				Default:     "",
+				Required:    false,
+				Description: "A column name that used to detect if the target table already contains the record.",
+			}},
 	}
 }


### PR DESCRIPTION
### Description

I've added a destination configuration with a unit test, and a method to parse it.
It will be used in a destination connector.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-oracle/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
