### PR TITLE
Fix batchSize validator

### DIFF
--- a/config/source_test.go
+++ b/config/source_test.go
@@ -68,6 +68,44 @@ func TestParseSource(t *testing.T) {
 			},
 		},
 		{
+			name: "valid config, batch size is maximum",
+			in: map[string]string{
+				models.ConfigURL:            "test_user/test_pass_123@localhost:1521/db_name",
+				models.ConfigTable:          "test_table",
+				models.ConfigOrderingColumn: "id",
+				models.ConfigKeyColumn:      "id",
+				models.ConfigBatchSize:      "100000",
+			},
+			want: Source{
+				General: General{
+					URL:       "test_user/test_pass_123@localhost:1521/db_name",
+					Table:     "TEST_TABLE",
+					KeyColumn: "ID",
+				},
+				OrderingColumn: "ID",
+				BatchSize:      100000,
+			},
+		},
+		{
+			name: "valid config, batch size is minimum",
+			in: map[string]string{
+				models.ConfigURL:            "test_user/test_pass_123@localhost:1521/db_name",
+				models.ConfigTable:          "test_table",
+				models.ConfigOrderingColumn: "id",
+				models.ConfigKeyColumn:      "id",
+				models.ConfigBatchSize:      "1",
+			},
+			want: Source{
+				General: General{
+					URL:       "test_user/test_pass_123@localhost:1521/db_name",
+					Table:     "TEST_TABLE",
+					KeyColumn: "ID",
+				},
+				OrderingColumn: "ID",
+				BatchSize:      1,
+			},
+		},
+		{
 			name: "valid config, custom columns",
 			in: map[string]string{
 				models.ConfigURL:            "test_user/test_pass_123@localhost:1521/db_name",
@@ -139,6 +177,39 @@ func TestParseSource(t *testing.T) {
 				models.ConfigColumns:        "id,age",
 			},
 			err: errors.New(validator.ColumnsIncludeErrMsg),
+		},
+		{
+			name: "invalid config, batchSize is too big",
+			in: map[string]string{
+				models.ConfigURL:            "test_user/test_pass_123@localhost:1521/db_name",
+				models.ConfigTable:          "test_table",
+				models.ConfigOrderingColumn: "id",
+				models.ConfigKeyColumn:      "id",
+				models.ConfigBatchSize:      "100001",
+			},
+			err: validator.OutOfRangeErr(models.ConfigBatchSize),
+		},
+		{
+			name: "invalid config, batchSize is zero",
+			in: map[string]string{
+				models.ConfigURL:            "test_user/test_pass_123@localhost:1521/db_name",
+				models.ConfigTable:          "test_table",
+				models.ConfigOrderingColumn: "id",
+				models.ConfigKeyColumn:      "id",
+				models.ConfigBatchSize:      "0",
+			},
+			err: validator.OutOfRangeErr(models.ConfigBatchSize),
+		},
+		{
+			name: "invalid config, batchSize is negative",
+			in: map[string]string{
+				models.ConfigURL:            "test_user/test_pass_123@localhost:1521/db_name",
+				models.ConfigTable:          "test_table",
+				models.ConfigOrderingColumn: "id",
+				models.ConfigKeyColumn:      "id",
+				models.ConfigBatchSize:      "-1",
+			},
+			err: validator.OutOfRangeErr(models.ConfigBatchSize),
 		},
 	}
 

--- a/config/validator/validator.go
+++ b/config/validator/validator.go
@@ -64,7 +64,7 @@ func Validate(s interface{}) error {
 				err = multierr.Append(err, RequiredErr(models.ConfigKeyName(e.Field())))
 			case "oracle":
 				err = multierr.Append(err, InvalidOracleObjectErr(models.ConfigKeyName(e.Field())))
-			case "lte":
+			case "gte", "lte":
 				err = multierr.Append(err, OutOfRangeErr(models.ConfigKeyName(e.Field())))
 			}
 		}


### PR DESCRIPTION
### Description

I've fixed a `batchSize` validator to check that it does not receive a negative value.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-oracle/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
