### PR TITLE
Add the if exists check before drop snapshot, refactoring iterator.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ information [inside the Change Data Capture section](#change-data-capture)).
 - if there is a need to change the columns in the target table, these changes must be made in the tracking table as
   well;
 - if the tracking table was deleted, it will be recreated on the next start;
-- creating two completely identical source connectors is not allowed.
+- creating two source connectors using the same table is not allowed.
 
 ### Configuration Options
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,6 @@ with `CONDUIT_TRACKING_ID` ordering column.
 The Ack method collects the `CONDUIT_TRACKING_ID` of those records that have been successfully applied, in order to
 remove them later in a batch from the tracking table (every 5 seconds or when the connector is closed).
 
-**Important**: If there is a need to change the columns in the target table, these changes must be made in the tracking
-table as well. If the tracking table was deleted, it will be recreated on the next start.
-
 ### Position
 
 Example of the position:
@@ -89,6 +86,13 @@ Snapshot mode it is the value from `orderingColumn` column you chose. This means
 unique values and suitable for sorting, otherwise the snapshot won't work correctly. For the CDC mode it is the value
 from `CONDUIT_TRACKING_ID` column of the tracking table (more
 information [inside the Change Data Capture section](#change-data-capture)).
+
+**Important**:
+
+- if there is a need to change the columns in the target table, these changes must be made in the tracking table as
+  well;
+- if the tracking table was deleted, it will be recreated on the next start;
+- creating two completely identical source connectors is not allowed.
 
 ### Configuration Options
 

--- a/source/iterator/quieries.go
+++ b/source/iterator/quieries.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	queryTableIsExists = `
+	queryIfTableExists = `
 SELECT table_name FROM user_tables WHERE table_name='%s'`
 
 	querySnapshotTable = `


### PR DESCRIPTION
### Description

I've added the check if the snapshot table exists before dropping it.
Also, I've moved to a separate method the check if a table exists in `iterator.go`.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-oracle/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
