### PR TITLE
Update the metadata's key of a table name

### DIFF
--- a/destination/writer/writer.go
+++ b/destination/writer/writer.go
@@ -33,6 +33,8 @@ const (
 	deleteFmt = "DELETE FROM %s WHERE %s = :1"
 	coma      = ","
 	equal     = "="
+
+	metadataTable = "oracle.table"
 )
 
 // Writer implements a writer logic for Oracle destination.
@@ -207,7 +209,7 @@ func (w *Writer) buildUpsertQuery(
 // returns either the record metadata value for the table
 // or the default configured value for the table.
 func (w *Writer) getTableName(metadata map[string]string) string {
-	tableName, ok := metadata["table"]
+	tableName, ok := metadata[metadataTable]
 	if !ok {
 		return w.table
 	}

--- a/source/iterator/constants.go
+++ b/source/iterator/constants.go
@@ -16,7 +16,7 @@ package iterator
 
 const (
 	// metadata related.
-	metadataTable = "table"
+	metadataTable = "oracle.table"
 
 	// actions.
 	actionInsert = "insert"


### PR DESCRIPTION
### Description

I've changed the metadata's key from `table` to `oracle.table`.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-oracle/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
