### PR TITLE
Move methods to their files

### DIFF
--- a/source/iterator/snapshot.go
+++ b/source/iterator/snapshot.go
@@ -16,8 +16,10 @@ package iterator
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"strings"
 	"time"
 
@@ -36,6 +38,10 @@ type Snapshot struct {
 	table string
 	// snapshotTable represents a name of snapshot table
 	snapshotTable string
+	// trackingTable represents a tracking table name
+	trackingTable string
+	// trigger represents a trigger name for a trackingTable
+	trigger string
 	// keyColumn represents a name of column what iterator use for setting key in record
 	keyColumn string
 	// orderingColumn represents a name of column what iterator use for sorting data
@@ -56,29 +62,65 @@ type SnapshotParams struct {
 	Repo           *repository.Oracle
 	Position       *Position
 	Table          string
-	SnapshotTable  string
 	KeyColumn      string
 	OrderingColumn string
 	Columns        []string
 	BatchSize      int
-	ColumnTypes    map[string]coltypes.ColumnDescription
 }
 
 // NewSnapshot creates a new instance of the Snapshot iterator.
 func NewSnapshot(ctx context.Context, params SnapshotParams) (*Snapshot, error) {
+	var err error
+
+	// hash the table name to use it as a postfix in the tracking table and snapshot,
+	// because the maximum length of names (tables, triggers, etc.) is 30 characters
+	h := fnv.New32a()
+	h.Write([]byte(params.Table))
+	hashedTable := h.Sum32()
+
 	iterator := &Snapshot{
 		repo:           params.Repo,
 		position:       params.Position,
 		table:          params.Table,
-		snapshotTable:  params.SnapshotTable,
+		snapshotTable:  fmt.Sprintf("CONDUIT_SNAPSHOT_%d", hashedTable),
+		trackingTable:  fmt.Sprintf("CONDUIT_TRACKING_%d", hashedTable),
+		trigger:        fmt.Sprintf("CONDUIT_%d", hashedTable),
 		keyColumn:      params.KeyColumn,
 		orderingColumn: params.OrderingColumn,
 		columns:        params.Columns,
 		batchSize:      params.BatchSize,
-		columnTypes:    params.ColumnTypes,
 	}
 
-	err := iterator.loadRows(ctx)
+	// get column types of table for converting
+	iterator.columnTypes, err = coltypes.GetColumnTypes(ctx, iterator.repo, iterator.table)
+	if err != nil {
+		return nil, fmt.Errorf("get table column types: %w", err)
+	}
+
+	tx, err := iterator.repo.DB.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin db transaction: %w", err)
+	}
+	defer tx.Rollback() // nolint:errcheck,nolintlint
+
+	// initialize a snapshot
+	err = iterator.initSnapshotTable(ctx, tx)
+	if err != nil {
+		return nil, fmt.Errorf("initialize snapshot: %w", err)
+	}
+
+	// initialize tracking table
+	err = iterator.initTrackingTable(ctx, tx)
+	if err != nil {
+		return nil, fmt.Errorf("initialize tracking table: %w", err)
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return nil, fmt.Errorf("commit db transaction: %w", err)
+	}
+
+	err = iterator.loadRows(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("load rows: %w", err)
 	}
@@ -96,7 +138,16 @@ func (iter *Snapshot) HasNext(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("load rows: %w", err)
 	}
 
-	return iter.rows.Next(), nil
+	hasNext := iter.rows.Next()
+	if !hasNext {
+		// drop a snapshot
+		err := iter.dropSnapshotTable(ctx)
+		if err != nil {
+			return hasNext, fmt.Errorf("drop snapshot: %w", err)
+		}
+	}
+
+	return hasNext, nil
 }
 
 // Next returns the next record.
@@ -160,6 +211,117 @@ func (iter *Snapshot) Next(_ context.Context) (sdk.Record, error) {
 func (iter *Snapshot) Close() error {
 	if iter.rows != nil {
 		return iter.rows.Close()
+	}
+
+	return nil
+}
+
+// initSnapshotTable creates a new snapshot table, if id does not exist.
+func (iter *Snapshot) initSnapshotTable(ctx context.Context, tx *sql.Tx) error {
+	exists, err := checkIfTableExists(ctx, tx, iter.snapshotTable)
+	if err != nil {
+		return fmt.Errorf("check if table exists: %w", err)
+	}
+
+	if exists {
+		return nil
+	}
+
+	// create a snapshot table
+	_, err = tx.ExecContext(ctx, fmt.Sprintf(querySnapshotTable, iter.snapshotTable, iter.table))
+	if err != nil {
+		return fmt.Errorf("create snapshot: %w", err)
+	}
+
+	return nil
+}
+
+// initTrackingTable creates a new tracking table and trigger, if they do not exist.
+func (iter *Snapshot) initTrackingTable(ctx context.Context, tx *sql.Tx) error {
+	exists, err := checkIfTableExists(ctx, tx, iter.trackingTable)
+	if err != nil {
+		return fmt.Errorf("check if table exists: %w", err)
+	}
+
+	if exists {
+		return nil
+	}
+
+	// create a copy of table
+	_, err = tx.ExecContext(ctx, fmt.Sprintf(queryTableCopy, iter.trackingTable, iter.table, iter.table))
+	if err != nil {
+		return fmt.Errorf("create copy of table: %w", err)
+	}
+
+	// add tracking columns to a tracking table
+	_, err = tx.ExecContext(ctx, fmt.Sprintf(queryTrackingTableExtendWithConduitColumns, iter.trackingTable,
+		columnTrackingID, columnOperationType, columnOperationType, columnTimeCreatedAt, iter.trackingTable,
+		columnTrackingID))
+	if err != nil {
+		return fmt.Errorf("expand tracking table with conduit columns: %w", err)
+	}
+
+	// add trigger
+	_, err = tx.ExecContext(ctx, iter.buildCreateTriggerQuery())
+	if err != nil {
+		return fmt.Errorf("create trigger: %w", err)
+	}
+
+	return nil
+}
+
+// buildCreateTriggerQuery returns a create trigger query.
+func (iter *Snapshot) buildCreateTriggerQuery() string {
+	var columnNames []string
+
+	if iter.columns != nil {
+		columnNames = append(columnNames, iter.columns...)
+	} else {
+		for key := range iter.columnTypes {
+			columnNames = append(columnNames, key)
+		}
+	}
+
+	newValues := make([]string, len(columnNames))
+	oldValues := make([]string, len(columnNames))
+	for i := range columnNames {
+		newValues[i] = fmt.Sprintf("%s%s", referencingNew, columnNames[i])
+		oldValues[i] = fmt.Sprintf("%s%s", referencingOld, columnNames[i])
+	}
+
+	insertOnInsertingOrUpdating := fmt.Sprintf(queryTriggerInsertPart, iter.trackingTable,
+		strings.Join(columnNames, ","), columnOperationType, strings.Join(newValues, ","))
+	insertOnDeleting := fmt.Sprintf(queryTriggerInsertPart, iter.trackingTable,
+		strings.Join(columnNames, ","), columnOperationType, strings.Join(oldValues, ","))
+
+	return fmt.Sprintf(queryTriggerCreate, iter.trigger, iter.table, insertOnInsertingOrUpdating, insertOnDeleting)
+}
+
+// dropSnapshotTable drops a snapshot, if it exists.
+func (iter *Snapshot) dropSnapshotTable(ctx context.Context) error {
+	tx, err := iter.repo.DB.Begin()
+	if err != nil {
+		return fmt.Errorf("begin db transaction: %w", err)
+	}
+	defer tx.Rollback() // nolint:errcheck,nolintlint
+
+	exists, err := checkIfTableExists(ctx, tx, iter.snapshotTable)
+	if err != nil {
+		return fmt.Errorf("check if table exists: %w", err)
+	}
+
+	if !exists {
+		return nil
+	}
+
+	_, err = tx.ExecContext(ctx, fmt.Sprintf("DROP SNAPSHOT %s", iter.snapshotTable))
+	if err != nil {
+		return fmt.Errorf("exec drop snapshot: %w", err)
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return fmt.Errorf("commit db transaction: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
### Description

I've moved the iterator's methods to their files.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-oracle/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
