### PR TITLE
Remove `t.Parallel` flags from integration tests

### DIFF
--- a/destination/destination_integration_test.go
+++ b/destination/destination_integration_test.go
@@ -30,8 +30,6 @@ import (
 )
 
 func TestDestination_Write(t *testing.T) {
-	t.Parallel()
-
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)
@@ -103,8 +101,6 @@ func TestDestination_Write(t *testing.T) {
 }
 
 func TestDestination_Write_Update(t *testing.T) {
-	t.Parallel()
-
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)
@@ -160,8 +156,6 @@ func TestDestination_Write_Update(t *testing.T) {
 }
 
 func TestDestination_Write_Upsert(t *testing.T) {
-	t.Parallel()
-
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)
@@ -214,8 +208,6 @@ func TestDestination_Write_Upsert(t *testing.T) {
 }
 
 func TestDestination_Write_Delete(t *testing.T) {
-	t.Parallel()
-
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)
@@ -271,8 +263,6 @@ func TestDestination_Write_Delete(t *testing.T) {
 }
 
 func TestDestination_Write_WrongColumn(t *testing.T) {
-	t.Parallel()
-
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)

--- a/source/source_integration_test.go
+++ b/source/source_integration_test.go
@@ -31,8 +31,6 @@ import (
 )
 
 func TestSource_Read_NoTable(t *testing.T) {
-	t.Parallel()
-
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)
@@ -58,8 +56,6 @@ func TestSource_Read_NoTable(t *testing.T) {
 }
 
 func TestSource_Read_EmptyTable(t *testing.T) {
-	t.Parallel()
-
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)
@@ -99,8 +95,6 @@ func TestSource_Read_EmptyTable(t *testing.T) {
 }
 
 func TestSource_Snapshot_Read(t *testing.T) {
-	t.Parallel()
-
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)
@@ -183,8 +177,6 @@ func TestSource_Snapshot_Read(t *testing.T) {
 }
 
 func TestSource_CDC_Read(t *testing.T) {
-	t.Parallel()
-
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)


### PR DESCRIPTION
### Description

I've removed `t.Parallel` flags from integration tests.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-oracle/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
