### PR TITLE
Split the config to the general and destination

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -25,30 +25,29 @@ const (
 	Table = "table"
 	// KeyColumn is the configuration name of the key column.
 	KeyColumn = "keyColumn"
+
+	testURL   = "test_user/test_pass_123@localhost:1521/db_name"
+	testTable = "test_table"
 )
 
-// A General represents a general configuration needed to connect to Oracle database.
-type General struct {
+// A Configuration represents a general configuration needed to connect to Oracle database.
+type Configuration struct {
 	// URL is the configuration of the connection string to connect to Oracle database.
 	URL string `json:"url" validate:"required"`
 	// Table is the configuration of the table name.
 	Table string `json:"table" validate:"required,lte=128,oracle"`
-	// KeyColumn is a column name that records should use for their `Key` fields (source) or
-	// is a column name uses to detect if the target table already contains the record (destination).
-	KeyColumn string `validate:"required,lte=128,oracle"`
 }
 
-// Parse parses general configuration.
-func Parse(cfg map[string]string) (General, error) {
-	config := General{
-		URL:       cfg[URL],
-		Table:     strings.ToUpper(cfg[Table]),
-		KeyColumn: strings.ToUpper(cfg[KeyColumn]),
+// parses general configuration.
+func parseConfiguration(cfg map[string]string) (Configuration, error) {
+	config := Configuration{
+		URL:   cfg[URL],
+		Table: strings.ToUpper(cfg[Table]),
 	}
 
 	err := validate(config)
 	if err != nil {
-		return General{}, err
+		return Configuration{}, err
 	}
 
 	return config, nil

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -25,9 +25,6 @@ const (
 	Table = "table"
 	// KeyColumn is the configuration name of the key column.
 	KeyColumn = "keyColumn"
-
-	testURL   = "test_user/test_pass_123@localhost:1521/db_name"
-	testTable = "test_table"
 )
 
 // A Configuration represents a general configuration needed to connect to Oracle database.

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -22,6 +22,11 @@ import (
 	"go.uber.org/multierr"
 )
 
+const (
+	testURL   = "test_user/test_pass_123@localhost:1521/db_name"
+	testTable = "test_table"
+)
+
 func TestParseGeneral(t *testing.T) {
 	t.Parallel()
 

--- a/config/destination.go
+++ b/config/destination.go
@@ -1,0 +1,48 @@
+// Copyright © 2022 Meroxa, Inc. & Yalantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Destination is a destination configuration needed to connect to Oracle database.
+type Destination struct {
+	Configuration
+
+	// KeyColumn is the column name uses to detect if the target table already contains the record.
+	KeyColumn string `validate:"required,lte=128,oracle"`
+}
+
+// ParseDestination parses a destination configuration.
+func ParseDestination(cfg map[string]string) (Destination, error) {
+	config, err := parseConfiguration(cfg)
+	if err != nil {
+		return Destination{}, fmt.Errorf("parse general config: %w", err)
+	}
+
+	destinationConfig := Destination{
+		Configuration: config,
+		KeyColumn:     strings.ToUpper(cfg[KeyColumn]),
+	}
+
+	err = validate(destinationConfig)
+	if err != nil {
+		return Destination{}, err
+	}
+
+	return destinationConfig, nil
+}

--- a/config/destination_test.go
+++ b/config/destination_test.go
@@ -1,0 +1,85 @@
+// Copyright © 2022 Meroxa, Inc. & Yalantis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseDestination(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   map[string]string
+		want Destination
+		err  error
+	}{
+		{
+			name: "success_required_values",
+			in: map[string]string{
+				URL:       testURL,
+				Table:     testTable,
+				KeyColumn: "id",
+			},
+			want: Destination{
+				Configuration: Configuration{
+					URL:   testURL,
+					Table: strings.ToUpper(testTable),
+				},
+				KeyColumn: strings.ToUpper("id"),
+			},
+		},
+		{
+			name: "failure_required_keyColumn",
+			in: map[string]string{
+				URL:   testURL,
+				Table: testTable,
+			},
+			err: errRequired(KeyColumn),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseDestination(tt.in)
+			if err != nil {
+				if tt.err == nil {
+					t.Errorf("unexpected error: %s", err.Error())
+
+					return
+				}
+
+				if err.Error() != tt.err.Error() {
+					t.Errorf("unexpected error, got: %s, want: %s", err.Error(), tt.err.Error())
+
+					return
+				}
+
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got: %v, want: %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/config/source.go
+++ b/config/source.go
@@ -33,10 +33,12 @@ const (
 
 // A Source represents a source configuration.
 type Source struct {
-	General
+	Configuration
 
 	// OrderingColumn is a name of a column that the connector will use for ordering rows.
 	OrderingColumn string `validate:"required,lte=128,oracle"`
+	// KeyColumn is a column name that records should use for their `Key` fields.
+	KeyColumn string `validate:"required,lte=128,oracle"`
 	// Columns list of column names that should be included in each Record's payload.
 	Columns []string `validate:"dive,lte=128,oracle"`
 	// BatchSize is a size of rows batch.
@@ -45,14 +47,15 @@ type Source struct {
 
 // ParseSource parses source configuration.
 func ParseSource(cfg map[string]string) (Source, error) {
-	config, err := Parse(cfg)
+	config, err := parseConfiguration(cfg)
 	if err != nil {
 		return Source{}, err
 	}
 
 	sourceConfig := Source{
-		General:        config,
+		Configuration:  config,
 		OrderingColumn: strings.ToUpper(cfg[OrderingColumn]),
+		KeyColumn:      strings.ToUpper(cfg[KeyColumn]),
 		BatchSize:      defaultBatchSize,
 	}
 

--- a/config/source_test.go
+++ b/config/source_test.go
@@ -17,6 +17,7 @@ package config
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -28,125 +29,125 @@ func TestParseSource(t *testing.T) {
 		err  error
 	}{
 		{
-			name: "valid config",
+			name: "success_required_values",
 			in: map[string]string{
-				URL:            "test_user/test_pass_123@localhost:1521/db_name",
-				Table:          "test_table",
+				URL:            testURL,
+				Table:          testTable,
 				OrderingColumn: "id",
 				KeyColumn:      "id",
 			},
 			want: Source{
-				General: General{
-					URL:       "test_user/test_pass_123@localhost:1521/db_name",
-					Table:     "TEST_TABLE",
-					KeyColumn: "ID",
+				Configuration: Configuration{
+					URL:   testURL,
+					Table: strings.ToUpper(testTable),
 				},
 				OrderingColumn: "ID",
+				KeyColumn:      "ID",
 				BatchSize:      defaultBatchSize,
 			},
 		},
 		{
-			name: "valid config, custom batch size",
+			name: "success_custom_batchSize",
 			in: map[string]string{
-				URL:            "test_user/test_pass_123@localhost:1521/db_name",
-				Table:          "test_table",
+				URL:            testURL,
+				Table:          testTable,
 				OrderingColumn: "id",
 				KeyColumn:      "id",
 				BatchSize:      "100",
 			},
 			want: Source{
-				General: General{
-					URL:       "test_user/test_pass_123@localhost:1521/db_name",
-					Table:     "TEST_TABLE",
-					KeyColumn: "ID",
+				Configuration: Configuration{
+					URL:   testURL,
+					Table: strings.ToUpper(testTable),
 				},
 				OrderingColumn: "ID",
+				KeyColumn:      "ID",
 				BatchSize:      100,
 			},
 		},
 		{
-			name: "valid config, batch size is maximum",
+			name: "success_batchSize_max",
 			in: map[string]string{
-				URL:            "test_user/test_pass_123@localhost:1521/db_name",
-				Table:          "test_table",
+				URL:            testURL,
+				Table:          testTable,
 				OrderingColumn: "id",
 				KeyColumn:      "id",
 				BatchSize:      "100000",
 			},
 			want: Source{
-				General: General{
-					URL:       "test_user/test_pass_123@localhost:1521/db_name",
-					Table:     "TEST_TABLE",
-					KeyColumn: "ID",
+				Configuration: Configuration{
+					URL:   testURL,
+					Table: strings.ToUpper(testTable),
 				},
 				OrderingColumn: "ID",
+				KeyColumn:      "ID",
 				BatchSize:      100000,
 			},
 		},
 		{
-			name: "valid config, batch size is minimum",
+			name: "success_batchSize_min",
 			in: map[string]string{
-				URL:            "test_user/test_pass_123@localhost:1521/db_name",
-				Table:          "test_table",
+				URL:            testURL,
+				Table:          testTable,
 				OrderingColumn: "id",
 				KeyColumn:      "id",
 				BatchSize:      "1",
 			},
 			want: Source{
-				General: General{
-					URL:       "test_user/test_pass_123@localhost:1521/db_name",
-					Table:     "TEST_TABLE",
-					KeyColumn: "ID",
+				Configuration: Configuration{
+					URL:   testURL,
+					Table: strings.ToUpper(testTable),
 				},
 				OrderingColumn: "ID",
+				KeyColumn:      "ID",
 				BatchSize:      1,
 			},
 		},
 		{
-			name: "valid config, custom columns",
+			name: "success_custom_columns",
 			in: map[string]string{
-				URL:            "test_user/test_pass_123@localhost:1521/db_name",
-				Table:          "test_table",
+				URL:            testURL,
+				Table:          testTable,
 				OrderingColumn: "id",
 				KeyColumn:      "id",
 				Columns:        "id, name,age",
 			},
 			want: Source{
-				General: General{
-					URL:       "test_user/test_pass_123@localhost:1521/db_name",
-					Table:     "TEST_TABLE",
-					KeyColumn: "ID",
+				Configuration: Configuration{
+					URL:   testURL,
+					Table: strings.ToUpper(testTable),
 				},
 				OrderingColumn: "ID",
+				KeyColumn:      "ID",
 				BatchSize:      defaultBatchSize,
 				Columns:        []string{"ID", "NAME", "AGE"},
 			},
 		},
 		{
-			name: "invalid config, missed ordering column",
+			name: "failure_required_orderingColumn",
 			in: map[string]string{
-				URL:       "test_user/test_pass_123@localhost:1521/db_name",
-				Table:     "test_table",
+				URL:       testURL,
+				Table:     testTable,
 				KeyColumn: "id",
 				Columns:   "id,name,age",
 			},
 			err: errors.New(`"orderingColumn" value must be set`),
 		},
 		{
-			name: "invalid config, missed key",
+			name: "failure_required_keyColumn",
 			in: map[string]string{
-				URL:            "test_user/test_pass_123@localhost:1521/db_name",
-				Table:          "test_table",
+				URL:            testURL,
+				Table:          testTable,
 				Columns:        "id,name,age",
 				OrderingColumn: "id",
 			},
 			err: errors.New(`"keyColumn" value must be set`),
 		},
 		{
-			name: "invalid config, invalid batch size",
+			name: "failure_invalid_batchSize",
 			in: map[string]string{
-				URL:            "test_user/test_pass_123@localhost:1521/db_name",
-				Table:          "test_table",
+				URL:            testURL,
+				Table:          testTable,
 				OrderingColumn: "id",
 				KeyColumn:      "id",
 				BatchSize:      "a",
@@ -154,10 +155,10 @@ func TestParseSource(t *testing.T) {
 			err: errors.New(`parse BatchSize: strconv.Atoi: parsing "a": invalid syntax`),
 		},
 		{
-			name: "invalid config, missed orderingColumn in columns",
+			name: "failure_missed_orderingColumn_in_columns",
 			in: map[string]string{
-				URL:            "test_user/test_pass_123@localhost:1521/db_name",
-				Table:          "test_table",
+				URL:            testURL,
+				Table:          testTable,
 				OrderingColumn: "id",
 				KeyColumn:      "name",
 				Columns:        "name,age",
@@ -165,10 +166,10 @@ func TestParseSource(t *testing.T) {
 			err: errColumnInclude(),
 		},
 		{
-			name: "invalid config, missed keyColumn in columns",
+			name: "failure_missed_keyColumn_in_columns",
 			in: map[string]string{
-				URL:            "test_user/test_pass_123@localhost:1521/db_name",
-				Table:          "test_table",
+				URL:            testURL,
+				Table:          testTable,
 				OrderingColumn: "id",
 				KeyColumn:      "name",
 				Columns:        "id,age",
@@ -176,10 +177,10 @@ func TestParseSource(t *testing.T) {
 			err: errColumnInclude(),
 		},
 		{
-			name: "invalid config, BatchSize is too big",
+			name: "failure_batchSize_is_too_big",
 			in: map[string]string{
-				URL:            "test_user/test_pass_123@localhost:1521/db_name",
-				Table:          "test_table",
+				URL:            testURL,
+				Table:          testTable,
 				OrderingColumn: "id",
 				KeyColumn:      "id",
 				BatchSize:      "100001",
@@ -187,10 +188,10 @@ func TestParseSource(t *testing.T) {
 			err: errOutOfRange(BatchSize),
 		},
 		{
-			name: "invalid config, BatchSize is zero",
+			name: "failure_batchSize_is_zero",
 			in: map[string]string{
-				URL:            "test_user/test_pass_123@localhost:1521/db_name",
-				Table:          "test_table",
+				URL:            testURL,
+				Table:          testTable,
 				OrderingColumn: "id",
 				KeyColumn:      "id",
 				BatchSize:      "0",
@@ -198,10 +199,10 @@ func TestParseSource(t *testing.T) {
 			err: errOutOfRange(BatchSize),
 		},
 		{
-			name: "invalid config, BatchSize is negative",
+			name: "failure_batchSize_is_negative",
 			in: map[string]string{
-				URL:            "test_user/test_pass_123@localhost:1521/db_name",
-				Table:          "test_table",
+				URL:            testURL,
+				Table:          testTable,
 				OrderingColumn: "id",
 				KeyColumn:      "id",
 				BatchSize:      "-1",

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -35,7 +35,7 @@ type Destination struct {
 
 	repo   *repository.Oracle
 	writer Writer
-	cfg    config.General
+	cfg    config.Destination
 }
 
 // NewDestination initialises a new Destination.
@@ -66,7 +66,7 @@ func (d *Destination) Parameters() map[string]sdk.Parameter {
 
 // Configure parses and stores configurations, returns an error in case of invalid configuration.
 func (d *Destination) Configure(_ context.Context, cfg map[string]string) error {
-	configuration, err := config.Parse(cfg)
+	configuration, err := config.ParseDestination(cfg)
 	if err != nil {
 		return err
 	}

--- a/destination/destination_integration_test.go
+++ b/destination/destination_integration_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/matryer/is"
 )
 
-func TestDestination_Write(t *testing.T) {
+func TestDestination_insert(t *testing.T) {
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)
@@ -100,7 +100,7 @@ func TestDestination_Write(t *testing.T) {
 	is.NoErr(err)
 }
 
-func TestDestination_Write_Update(t *testing.T) {
+func TestDestination_update(t *testing.T) {
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)
@@ -155,7 +155,7 @@ func TestDestination_Write_Update(t *testing.T) {
 	is.NoErr(err)
 }
 
-func TestDestination_Write_Upsert(t *testing.T) {
+func TestDestination_upsert(t *testing.T) {
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)
@@ -207,7 +207,7 @@ func TestDestination_Write_Upsert(t *testing.T) {
 	is.NoErr(err)
 }
 
-func TestDestination_Write_Delete(t *testing.T) {
+func TestDestination_delete(t *testing.T) {
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)
@@ -262,7 +262,7 @@ func TestDestination_Write_Delete(t *testing.T) {
 	is.NoErr(err)
 }
 
-func TestDestination_Write_WrongColumn(t *testing.T) {
+func TestDestination_wrongColumn(t *testing.T) {
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)

--- a/destination/destination_test.go
+++ b/destination/destination_test.go
@@ -28,7 +28,12 @@ import (
 	"github.com/matryer/is"
 )
 
-func TestDestination_ConfigureSuccess(t *testing.T) {
+var (
+	testURL   = "test_user/test_pass_123@localhost:1521/db_name"
+	testTable = "test_table"
+)
+
+func TestDestination_Configure_success(t *testing.T) {
 	t.Parallel()
 
 	is := is.New(t)
@@ -36,19 +41,21 @@ func TestDestination_ConfigureSuccess(t *testing.T) {
 	d := Destination{}
 
 	err := d.Configure(context.Background(), map[string]string{
-		config.URL:       "test_user/test_pass_123@localhost:1521/db_name",
-		config.Table:     "test_table",
+		config.URL:       testURL,
+		config.Table:     testTable,
 		config.KeyColumn: "id",
 	})
 	is.NoErr(err)
-	is.Equal(d.cfg, config.General{
-		URL:       "test_user/test_pass_123@localhost:1521/db_name",
-		Table:     strings.ToUpper("test_table"),
+	is.Equal(d.cfg, config.Destination{
+		Configuration: config.Configuration{
+			URL:   testURL,
+			Table: strings.ToUpper(testTable),
+		},
 		KeyColumn: strings.ToUpper("id"),
 	})
 }
 
-func TestDestination_ConfigureFail(t *testing.T) {
+func TestDestination_Configure_failure(t *testing.T) {
 	t.Parallel()
 
 	is := is.New(t)
@@ -56,12 +63,12 @@ func TestDestination_ConfigureFail(t *testing.T) {
 	d := Destination{}
 
 	err := d.Configure(context.Background(), map[string]string{
-		config.URL: "test_user/test_pass_123@localhost:1521/db_name",
+		config.URL: testURL,
 	})
 	is.True(err != nil)
 }
 
-func TestDestination_WriteSuccess(t *testing.T) {
+func TestDestination_Write_success(t *testing.T) {
 	t.Parallel()
 
 	is := is.New(t)
@@ -115,7 +122,7 @@ func TestDestination_WriteSuccess(t *testing.T) {
 	is.Equal(n, len(records))
 }
 
-func TestDestination_WriteFail(t *testing.T) {
+func TestDestination_Write_failure(t *testing.T) {
 	t.Parallel()
 
 	is := is.New(t)
@@ -141,7 +148,7 @@ func TestDestination_WriteFail(t *testing.T) {
 	is.Equal(n, 0)
 }
 
-func TestDestination_TeardownSuccess(t *testing.T) {
+func TestDestination_Teardown_success(t *testing.T) {
 	t.Parallel()
 
 	is := is.New(t)
@@ -157,7 +164,7 @@ func TestDestination_TeardownSuccess(t *testing.T) {
 	is.NoErr(err)
 }
 
-func TestDestination_TeardownSuccessNilWriter(t *testing.T) {
+func TestDestination_Teardown_successNilWriter(t *testing.T) {
 	t.Parallel()
 
 	is := is.New(t)

--- a/source/source_integration_test.go
+++ b/source/source_integration_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/matryer/is"
 )
 
-func TestSource_Read_NoTable(t *testing.T) {
+func TestSource_noTable(t *testing.T) {
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)
@@ -55,7 +55,7 @@ func TestSource_Read_NoTable(t *testing.T) {
 	cancel()
 }
 
-func TestSource_Read_EmptyTable(t *testing.T) {
+func TestSource_emptyTable(t *testing.T) {
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)
@@ -94,7 +94,7 @@ func TestSource_Read_EmptyTable(t *testing.T) {
 	is.NoErr(err)
 }
 
-func TestSource_Snapshot_Read(t *testing.T) {
+func TestSource_snapshotRead(t *testing.T) {
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)
@@ -176,7 +176,7 @@ func TestSource_Snapshot_Read(t *testing.T) {
 	is.NoErr(err)
 }
 
-func TestSource_CDC_Read(t *testing.T) {
+func TestSource_cdcRead(t *testing.T) {
 	var (
 		ctx = context.Background()
 		cfg = prepareConfig(t)

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -27,7 +27,12 @@ import (
 	"github.com/matryer/is"
 )
 
-func TestSource_ConfigureSuccess(t *testing.T) {
+var (
+	testURL   = "test_user/test_pass_123@localhost:1521/db_name"
+	testTable = "test_table"
+)
+
+func TestSource_Configure_success(t *testing.T) {
 	t.Parallel()
 
 	is := is.New(t)
@@ -35,24 +40,24 @@ func TestSource_ConfigureSuccess(t *testing.T) {
 	s := Source{}
 
 	err := s.Configure(context.Background(), map[string]string{
-		config.URL:            "test_user/test_pass_123@localhost:1521/db_name",
-		config.Table:          "test_table",
+		config.URL:            testURL,
+		config.Table:          testTable,
 		config.KeyColumn:      "id",
 		config.OrderingColumn: "created_at",
 	})
 	is.NoErr(err)
 	is.Equal(s.config, config.Source{
-		General: config.General{
-			URL:       "test_user/test_pass_123@localhost:1521/db_name",
-			Table:     strings.ToUpper("test_table"),
-			KeyColumn: strings.ToUpper("id"),
+		Configuration: config.Configuration{
+			URL:   testURL,
+			Table: strings.ToUpper(testTable),
 		},
 		OrderingColumn: strings.ToUpper("created_at"),
+		KeyColumn:      strings.ToUpper("id"),
 		BatchSize:      1000,
 	})
 }
 
-func TestSource_ConfigureFail(t *testing.T) {
+func TestSource_Configure_failure(t *testing.T) {
 	t.Parallel()
 
 	is := is.New(t)
@@ -60,14 +65,14 @@ func TestSource_ConfigureFail(t *testing.T) {
 	s := Source{}
 
 	err := s.Configure(context.Background(), map[string]string{
-		config.URL:       "test_user/test_pass_123@localhost:1521/db_name",
-		config.Table:     "test_table",
+		config.URL:       testURL,
+		config.Table:     testTable,
 		config.KeyColumn: "id",
 	})
 	is.True(err != nil)
 }
 
-func TestSource_ReadSuccess(t *testing.T) {
+func TestSource_Read_success(t *testing.T) {
 	t.Parallel()
 
 	is := is.New(t)
@@ -99,7 +104,7 @@ func TestSource_ReadSuccess(t *testing.T) {
 	is.Equal(r, record)
 }
 
-func TestSource_ReadHasNextFail(t *testing.T) {
+func TestSource_Read_failureHasNext(t *testing.T) {
 	t.Parallel()
 
 	is := is.New(t)
@@ -118,7 +123,7 @@ func TestSource_ReadHasNextFail(t *testing.T) {
 	is.True(err != nil)
 }
 
-func TestSource_ReadNextFail(t *testing.T) {
+func TestSource_Read_failureNext(t *testing.T) {
 	t.Parallel()
 
 	is := is.New(t)
@@ -138,7 +143,7 @@ func TestSource_ReadNextFail(t *testing.T) {
 	is.True(err != nil)
 }
 
-func TestSource_TeardownSuccess(t *testing.T) {
+func TestSource_Teardown_success(t *testing.T) {
 	t.Parallel()
 
 	is := is.New(t)
@@ -156,7 +161,7 @@ func TestSource_TeardownSuccess(t *testing.T) {
 	is.NoErr(err)
 }
 
-func TestSource_TeardownFail(t *testing.T) {
+func TestSource_Teardown_failure(t *testing.T) {
 	t.Parallel()
 
 	is := is.New(t)


### PR DESCRIPTION
### Description

In the nearest future, we have to use deferent validation rules for the `keyColumn` configuration field.
So, I've moved this field from the configuration to the source and destination.

Also, I've updated the names of unit tests.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-oracle/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
