### PR TITLE
Fix the name of a default table name in the metadata for the source

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,4 +16,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.3.1
         with:
-          version: v1.49.0
+          version: v1.50.1

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ installed. See [Godror Installation](https://godror.github.io/godror/doc/install
 ## Prerequisites
 
 - [Go](https://go.dev/) 1.18
-- (optional) [golangci-lint](https://github.com/golangci/golangci-lint) 1.49.0
+- (optional) [golangci-lint](https://github.com/golangci/golangci-lint) 1.50.1
 
 ## How to build it
 

--- a/source/iterator/iterator.go
+++ b/source/iterator/iterator.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	metadataTable = "clickhouse.table"
+	metadataTable = "oracle.table"
 
 	columnTrackingID    = "CONDUIT_TRACKING_ID"
 	columnOperationType = "CONDUIT_OPERATION_TYPE"


### PR DESCRIPTION
### Description

This pull request contains the fix of the name of a default table name in the metadata for the source.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-oracle/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
