### PR TITLE
Add the lte validation of the Source keyColumns field

### DIFF
--- a/config/source.go
+++ b/config/source.go
@@ -45,7 +45,7 @@ type Source struct {
 	// OrderingColumn is a name of a column that the connector will use for ordering rows.
 	OrderingColumn string `validate:"required,lte=128,oracle"`
 	// KeyColumns is the configuration of key column names, separated by commas.
-	KeyColumns []string `validate:"omitempty,dive,oracle"`
+	KeyColumns []string `validate:"omitempty,dive,lte=128,oracle"`
 	// Snapshot is the configuration that determines whether the connector
 	// will take a snapshot of the entire table before starting cdc mode.
 	Snapshot bool

--- a/config/source_test.go
+++ b/config/source_test.go
@@ -332,6 +332,17 @@ func TestParseSource(t *testing.T) {
 			err: fmt.Errorf("columns must include all %q", KeyColumns),
 		},
 		{
+			name: "failure_keyColumn_is_too_big",
+			in: map[string]string{
+				URL:            testURL,
+				Table:          testTable,
+				OrderingColumn: "id",
+				KeyColumns: "CREZSK8VR1LM5F0RZ5NA7FGJ0CNNVTTFNZDJKCWD8KKCU7UKZAW0NRNCZRQNM4EIAMEG0K7BGV2GX8UTDL" +
+					"RLM8HGNFEYSSEXAL7V8GVFKWU8PQABQ1FH6LHEVFVGZ9XUF",
+			},
+			err: fmt.Errorf("%q is out of range", KeyColumns),
+		},
+		{
 			name: "failure_batchSize_is_too_big",
 			in: map[string]string{
 				URL:            testURL,

--- a/config/validator.go
+++ b/config/validator.go
@@ -17,6 +17,7 @@ package config
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"sync"
 
 	v "github.com/go-playground/validator/v10"
@@ -62,6 +63,7 @@ func validate(s interface{}) error {
 			case "oracle":
 				err = multierr.Append(err, errInvalidOracleObject(getKeyName(e.Field())))
 			case "gte", "lte":
+				fmt.Println(e.Field())
 				err = multierr.Append(err, errOutOfRange(getKeyName(e.Field())))
 			}
 		}
@@ -87,7 +89,18 @@ func validateOracleObject(fl v.FieldLevel) bool {
 	return isOracleObjectValid(fl.Field().String())
 }
 
+// openSquareBracket is a substring, by which
+// the element number of the slice is separated from the field name.
+const openSquareBracket = "["
+
 func getKeyName(fieldName string) string {
+	// if the field name contains a slice element,
+	// separate the information about the array element,
+	// and leave the field name unchanged
+	if strings.Contains(fieldName, openSquareBracket) {
+		fieldName = strings.Split(fieldName, openSquareBracket)[0]
+	}
+
 	return map[string]string{
 		"URL":            URL,
 		"Table":          Table,

--- a/config/validator.go
+++ b/config/validator.go
@@ -63,7 +63,6 @@ func validate(s interface{}) error {
 			case "oracle":
 				err = multierr.Append(err, errInvalidOracleObject(getKeyName(e.Field())))
 			case "gte", "lte":
-				fmt.Println(e.Field())
 				err = multierr.Append(err, errOutOfRange(getKeyName(e.Field())))
 			}
 		}


### PR DESCRIPTION
### Description

I've added the `lte` validation rule for the Source `keyColumns` field, that each of the column key should be less than 128 symbols.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-oracle/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
