### PR TITLE
Rename default tracking table columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,21 +55,22 @@ the CDC mode.
 ### Change Data Capture
 
 This connector implements CDC features for Oracle by adding a tracking table and a trigger to populate it. The tracking
-table and trigger name have the same names as a source table with the prefix `CONDUIT`. The tracking table has all the
-same columns as the source table plus three additional columns:
+table and trigger name have the same names as a source table with the prefix `CONDUIT` by default. See configuration options `trackingTable`, `trigger`, and `snapshotTable` if you would like to customize the naming.
 
-| name                          | description                                         |
-|-------------------------------|-----------------------------------------------------|
-| `CONDUIT_TRACKING_ID`         | Autoincrement index for the position.               |
-| `CONDUIT_OPERATION_TYPE`      | Operation type: `insert`, `update`, or `delete`.    |
-| `CONDUIT_TRACKING_CREATED_AT` | Date when the event was added to the tacking table. |
+The tracking table has all the same columns as the source table plus three additional columns:
+
+| name                           | description                                        |
+|--------------------------------|----------------------------------------------------|
+| `CONNECTOR_TRACKING_ID`        | Autoincrement index for the position.              |
+| `CONNECTOR_OPERATION_TYPE`     | Operation type: `insert`, `update`, or `delete`.   |
+| `CONNECTOR_TRACKING_CREATED_AT`| Date when the event was added to the tacking table.|
 
 Every time data is added, changed, or deleted from the source table, this event will be written to the tracking table.
 
 Queries to retrieve change data from a tracking table are very similar to queries in a Snapshot mode, but
-with `CONDUIT_TRACKING_ID` ordering column.
+with `CONNECTOR_TRACKING_ID` ordering column.
 
-The Ack method collects the `CONDUIT_TRACKING_ID` of those records that have been successfully applied, in order to
+The Ack method collects the `CONNECTOR_TRACKING_ID` of those records that have been successfully applied, in order to
 remove them later in a batch from the tracking table (every 5 seconds or when the connector is closed).
 
 ### Position

--- a/source/iterator/iterator.go
+++ b/source/iterator/iterator.go
@@ -30,9 +30,9 @@ import (
 const (
 	metadataTable = "oracle.table"
 
-	columnTrackingID    = "CONDUIT_TRACKING_ID"
-	columnOperationType = "CONDUIT_OPERATION_TYPE"
-	columnTimeCreatedAt = "CONDUIT_TRACKING_CREATED_AT"
+	columnTrackingID    = "CONNECTOR_TRACKING_ID"
+	columnOperationType = "CONNECTOR_OPERATION_TYPE"
+	columnTimeCreatedAt = "CONNECTOR_TRACKING_CREATED_AT"
 
 	queryIfTableExists     = "SELECT * FROM user_tables WHERE table_name='%s'"
 	querySelectRowsFmt     = "SELECT %s FROM %s%s ORDER BY %s ASC FETCH NEXT %d ROWS ONLY"


### PR DESCRIPTION
### Description
Renames the default columns on the tracking table, to be prefixed by `CONNECTOR_`.


### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-oracle/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
